### PR TITLE
Feature/chord stacking

### DIFF
--- a/app/NoteSlot.qml
+++ b/app/NoteSlot.qml
@@ -80,7 +80,7 @@ Rectangle {
         source: "images/redx.gif"
         width: 27
         height: 27
-        visible: gradeCount > 0 && selected && !gridController.isBeatCorrect(beat)
+        visible: gradeCount > 0 && selected && gridController.isNoteIncorrect(beat, row)
         playing: visible
         cache: false
         speed: 2
@@ -124,7 +124,7 @@ Rectangle {
                 // Only show on note start beats (len > 0), not continuations
                 selected = hasNoteHere && len > 0
                 if (selected) {
-                    var acc = gridController.accidentalForBeat(beat)
+                    var acc = gridController.accidentalForBeatRow(beat, row)
 
                     // Note body: always use the plain note image so the flip transform
                     // controls stem direction independently of any accidental.
@@ -186,7 +186,7 @@ Rectangle {
     onSelectedChanged: root.state = root.selected ? "clicked" : ""
     onGradeCountChanged: {
         wrongMark.currentFrame = 0
-        wrongMark.playing = (gradeCount > 0 && selected && !gridController.isBeatCorrect(beat))
+        wrongMark.playing = (gradeCount > 0 && selected && gridController.isNoteIncorrect(beat, row))
     }
 
     states: [

--- a/app/Screen01.qml
+++ b/app/Screen01.qml
@@ -18,7 +18,18 @@ Rectangle {
     property int currentScore: 0
     property var wrongBeats: []
     property int gradeCount: 0 // increments each time grade is clicked
-    onCurrentAccChanged: console.log("currentAcc now", currentAcc) 
+    onCurrentAccChanged: console.log("currentAcc now", currentAcc)
+
+    // Reset local score state whenever the controller loads a new question
+    Connections {
+        target: gridController
+        function onQuestionChanged() {
+            currentScore = 0
+            wrongBeats   = []
+            gradeCount   = 0
+        }
+    }
+
     Image {
         id: staffLines2
         x: 53
@@ -36,7 +47,7 @@ Rectangle {
 
         // Measure 1 (8 slots × 14 rows = 112)
         Repeater {
-            model: 112
+            model: 184
             NoteSlot {
                 wrongBeats: rectangle.wrongBeats
                 gradeCount: rectangle.gradeCount
@@ -90,14 +101,14 @@ Rectangle {
         Text {
             text: gridController.currentQuestionText
             font.pixelSize: 28
-            leftPadding: 0
             color: "black"
+            anchors.horizontalCenter: parent.horizontalCenter
         }
         Image {
             source: "images/gradebutton.png"
             fillMode: Image.PreserveAspectFit
             height: 40
-            x: 20
+            anchors.horizontalCenter: parent.horizontalCenter
             opacity: gradeArea.pressed ? 0.6 : 1.0
             MouseArea {
                 id: gradeArea
@@ -111,6 +122,7 @@ Rectangle {
         }
         Row {
             spacing: 10
+            anchors.horizontalCenter: parent.horizontalCenter
 
             Image {
                 source: "images/flatbutton.png"
@@ -145,7 +157,7 @@ Rectangle {
         }
         Row {
             spacing: 10
-            x: -40
+            anchors.horizontalCenter: parent.horizontalCenter
             Image {
                 source: "images/eighthbutton.png"
                 fillMode: Image.PreserveAspectFit
@@ -186,14 +198,44 @@ Rectangle {
                     onClicked: rectangle.currentNoteLength = 4
                 }
             }
-            
+
         }
 
+        // Question navigation
+        Row {
+            spacing: 30
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            Text {
+                text: "◀ Back"
+                font.pixelSize: 24
+                color: backArea.containsPress ? "#888888" : "black"
+                MouseArea {
+                    id: backArea
+                    anchors.fill: parent
+                    onClicked: gridController.previousQuestion()
+                }
+            }
+
+            Text {
+                text: "Question " + gridController.currentQuestionNum + " / " + gridController.totalQuestionsAvailable()
+                font.pixelSize: 24
+                color: "black"
+            }
+
+            Text {
+                text: "Next ▶"
+                font.pixelSize: 24
+                color: nextArea.containsPress ? "#888888" : "black"
+                MouseArea {
+                    id: nextArea
+                    anchors.fill: parent
+                    onClicked: gridController.nextQuestion()
+                }
+            }
+        }
     }
-
-
-
-
 }
+
 
 

--- a/core/GridController.cpp
+++ b/core/GridController.cpp
@@ -12,7 +12,7 @@ GridController::GridController(QObject *parent)
     expectedRow.fill(-1);
 
     expectedAccidental.fill(0);
-    userAccidental.fill(0);    
+    for (auto& rowArr : userAccidental) rowArr.fill(0);
     userLength.fill(0);
     expectedLength.fill(0);
     // Example answer (change these to your melody):
@@ -70,7 +70,7 @@ void GridController::clearBeatInternal(int beat) {
 void GridController::clearBeat(int beat) {
     if (beat < 0 || beat >= StaffLineGrid::columns) return;
     clearBeatInternal(beat);
-    userAccidental[beat] = 0;
+    userAccidental[beat].fill(0);
     userLength[beat] = 0;
     emit beatChanged(beat);
 }
@@ -81,17 +81,30 @@ void GridController::setNote(int beat, int row, int acc, int length) {
     if (length <= 0) return;
     if (beat + length > StaffLineGrid::columns) return;
 
-    // Question-based restrictions
+    // Question-based restrictions (apply to both paths)
     if (!isLengthAllowed(length)) return;
     if (!isStartColumnAllowed(beat)) return;
 
-    if (!m_allowStacking) {
-        for (int r = 0; r < StaffLineGrid::rows; ++r) {
-            if (userGrid.HasNote(beat, r)) {
-            return;
-            }
-        }
-    }   
+    // ── Stacking path ────────────────────────────────────────────────────────
+    // Only touch the target (beat, row). All other rows at this beat survive.
+    if (m_allowStacking) {
+        userGrid.RemoveNote(beat, row);       // no-op if the cell was empty
+        userAccidental[beat][row] = 0;
+
+        userGrid.AddNote(beat, row, length);
+        userAccidental[beat][row] = acc;
+        userLength[beat] = length;            // all chord notes share one duration
+
+        for (int i = 0; i < length; ++i)
+            emit beatChanged(beat + i);
+        return;
+    }
+
+    // ── Non-stacking path (original behaviour) ────────────────────────────────
+    // Abort if any note already exists anywhere on this beat
+    for (int r = 0; r < StaffLineGrid::rows; ++r) {
+        if (userGrid.HasNote(beat, r)) return;
+    }
 
     const int measureStart = (beat / 8) * 8;
     const int measureOffset = beat % 8;
@@ -99,33 +112,20 @@ void GridController::setNote(int beat, int row, int acc, int length) {
     // Prevent crossing the current measure boundary
     if (measureOffset + length > 8) return;
 
-    // Enforce notation-based start positions for 4/4 with 8 columns per measure
+    // Enforce notation-based start positions for 4/4 with 8 columns per measure.
+    // length uses the UI type-ID convention: 4=whole, 3=half, 2=quarter, 1=eighth.
     switch (length) {
-        case 8: // whole note: beat 1 only
-            if (measureOffset != 0) return;
-            break;
-
-        case 4: // half note: beats 1 or 3
-            if (measureOffset != 0 && measureOffset != 4) return;
-            break;
-
-        case 2: // quarter note: beats 1, 2, 3, 4
-            if (measureOffset % 2 != 0) return;
-            break;
-
-        case 1: // eighth note: anywhere
-            break;
-
-        default:
-            return; // unsupported note length
+        case 4: if (measureOffset != 0) return; break;                       // whole: beat 1 only
+        case 3: if (measureOffset != 0 && measureOffset != 4) return; break; // half: beats 1 or 3
+        case 2: if (measureOffset % 2 != 0) return; break;                   // quarter: beats 1-4
+        case 1: break;                                                         // eighth: anywhere
+        default: return;
     }
 
     const int measureEnd = measureStart + 8;
 
-    // Track which beats in this measure need UI refresh
     bool beatsToRefresh[8] = { false };
 
-    // Simulate currently occupied columns in this measure
     bool occupied[8] = { false };
     for (int c = measureStart; c < measureEnd; ++c) {
         if (noteRowForBeat(c) != -1) {
@@ -133,17 +133,13 @@ void GridController::setNote(int beat, int row, int acc, int length) {
         }
     }
 
-    // Simulate clearing any note touched by the new note.
-    // RemoveNote removes the entire existing note, not just one column.
     for (int c = beat; c < beat + length; ++c) {
         for (int r = 0; r < StaffLineGrid::rows; ++r) {
             if (!userGrid.HasNote(c, r)) continue;
 
-            // Find the start of the existing note on this row
             int noteStart = c;
-            while (noteStart > measureStart && userGrid.HasNote(noteStart - 1, r)) {
+            while (noteStart > measureStart && userGrid.HasNote(noteStart - 1, r))
                 --noteStart;
-            }
 
             int existingLength = userLength[noteStart];
             if (existingLength <= 0) existingLength = 1;
@@ -156,44 +152,41 @@ void GridController::setNote(int beat, int row, int acc, int length) {
     }
 
     int occupiedAfterClear = 0;
-    for (int i = 0; i < 8; ++i) {
-        if (occupied[i]) {
-            ++occupiedAfterClear;
-        }
-    }
+    for (int i = 0; i < 8; ++i)
+        if (occupied[i]) ++occupiedAfterClear;
 
-    // Reject if total occupied duration in the measure would exceed capacity
     if (occupiedAfterClear + length > 8) return;
 
-    // Clear all beats this note will occupy
     for (int i = 0; i < length; ++i) {
         clearBeatInternal(beat + i);
-        userAccidental[beat + i] = 0;
+        userAccidental[beat + i].fill(0);
         userLength[beat + i] = 0;
         beatsToRefresh[beat + i - measureStart] = true;
     }
 
-    // Place the new note
     userGrid.AddNote(beat, row, length);
-    userAccidental[beat] = acc;
+    userAccidental[beat][row] = acc;
     userLength[beat] = length;
 
-    // Refresh the new note's occupied columns too
-    for (int i = 0; i < length; ++i) {
+    for (int i = 0; i < length; ++i)
         beatsToRefresh[beat + i - measureStart] = true;
-    }
 
-    // Emit updates for every affected beat in the measure
-    for (int i = 0; i < 8; ++i) {
-        if (beatsToRefresh[i]) {
-            emit beatChanged(measureStart + i);
-        }
-    }
+    for (int i = 0; i < 8; ++i)
+        if (beatsToRefresh[i]) emit beatChanged(measureStart + i);
 }
 
 int GridController::accidentalForBeat(int beat) const {
-    if (beat < 0 || beat >= (int)userAccidental.size()) return 0;
-    return userAccidental[beat];
+    // Returns the accidental of the lowest placed note at this beat.
+    // Use accidentalForBeatRow() when per-row precision is needed.
+    int row = noteRowForBeat(beat);
+    if (row < 0 || beat < 0 || beat >= StaffLineGrid::columns) return 0;
+    return userAccidental[beat][row];
+}
+
+int GridController::accidentalForBeatRow(int beat, int row) const {
+    if (beat < 0 || beat >= StaffLineGrid::columns) return 0;
+    if (row < 0 || row >= StaffLineGrid::rows) return 0;
+    return userAccidental[beat][row];
 }
 
 int GridController::noteLengthForBeat(int beat) const {
@@ -220,37 +213,112 @@ void GridController::setExpectedRow(int beat, int row, int acc, int length) {
     emit expectedChanged(beat);
 }
 
+bool GridController::isNoteIncorrect(int beat, int row) const {
+    if (beat < 0 || beat >= StaffLineGrid::columns) return false;
+    if (row < 0 || row >= StaffLineGrid::rows) return false;
+
+    if (!m_allowStacking) {
+        // Non-stacking: a placed note is wrong iff the whole beat is wrong
+        return !isBeatCorrect(beat);
+    }
+
+    // Stacking: evaluate only this specific (beat, row) note
+    if (!userGrid.HasNote(beat, row)) return false; // nothing placed here
+
+    for (const NoteInfo& exp : m_expectedNotes) {
+        if (exp.beat == beat && exp.row == row)
+            return userAccidental[beat][row] != exp.accent; // expected but wrong accidental?
+    }
+    return true; // placed but not expected → wrong
+}
+
 bool GridController::isBeatCorrect(int beat) const {
     if (beat < 0 || beat >= StaffLineGrid::columns) return false;
-    return noteRowForBeat(beat) == expectedRow[beat]
-        && userAccidental[beat] == expectedAccidental[beat];
-        
+
+    if (!m_allowStacking) {
+        // Non-stacking: one expected row per beat
+        int userRow = noteRowForBeat(beat);
+        if (userRow != expectedRow[beat]) return false;
+        if (expectedRow[beat] == -1) return true; // both empty
+        return userAccidental[beat][userRow] == expectedAccidental[beat];
+    }
+
+    // Stacking: every expected note at this beat must be present with the
+    // correct accidental, and no unexpected notes may exist.
+    bool anyExpected = false;
+    for (const NoteInfo& exp : m_expectedNotes) {
+        if (exp.beat != beat) continue;
+        anyExpected = true;
+        if (!userGrid.HasNote(beat, exp.row)) return false;
+        if (userAccidental[beat][exp.row] != exp.accent) return false;
+    }
+    if (!anyExpected) return true;
+
+    for (int r = 0; r < StaffLineGrid::rows; ++r) {
+        if (!userGrid.HasNote(beat, r)) continue;
+        bool isExpected = false;
+        for (const NoteInfo& exp : m_expectedNotes)
+            if (exp.beat == beat && exp.row == r) { isExpected = true; break; }
+        if (!isExpected) return false;
+    }
+    return true;
 }
 
 
 QVariantList GridController::incorrectBeats() const {
     QVariantList wrong;
-    for (int b = 0; b < StaffLineGrid::columns; ++b) {
-        if (expectedRow[b] == -1) continue; // skip beats with no expected note
-        if (!isBeatCorrect(b)) wrong.append(b);
+    if (!m_allowStacking) {
+        for (int b = 0; b < StaffLineGrid::columns; ++b) {
+            if (expectedRow[b] == -1) continue;
+            if (!isBeatCorrect(b)) wrong.append(b);
+        }
+        return wrong;
     }
+    // Stacking: collect distinct beats that have expected notes and are wrong
+    bool hasBeat[StaffLineGrid::columns] = {};
+    for (const NoteInfo& note : m_expectedNotes)
+        if (note.beat >= 0 && note.beat < StaffLineGrid::columns)
+            hasBeat[note.beat] = true;
+    for (int b = 0; b < StaffLineGrid::columns; ++b)
+        if (hasBeat[b] && !isBeatCorrect(b)) wrong.append(b);
     return wrong;
 }
 
 int GridController::score() const {
-    int s = 0;
-    for (int b = 0; b < StaffLineGrid::columns; ++b) {
-        if (expectedRow[b] == -1) continue;
-        if (isBeatCorrect(b)) ++s;
+    if (!m_allowStacking) {
+        int s = 0;
+        for (int b = 0; b < StaffLineGrid::columns; ++b) {
+            if (expectedRow[b] == -1) continue;
+            if (isBeatCorrect(b)) ++s;
+        }
+        return s;
     }
+    // Stacking: one point per beat where every expected chord note is correct
+    bool hasBeat[StaffLineGrid::columns] = {};
+    for (const NoteInfo& note : m_expectedNotes)
+        if (note.beat >= 0 && note.beat < StaffLineGrid::columns)
+            hasBeat[note.beat] = true;
+    int s = 0;
+    for (int b = 0; b < StaffLineGrid::columns; ++b)
+        if (hasBeat[b] && isBeatCorrect(b)) ++s;
     return s;
 }
 
 int GridController::totalExpected() const {
-    int t = 0;
-    for (int b = 0; b < StaffLineGrid::columns; ++b) {
-        if (expectedRow[b] != -1) ++t;
+    if (!m_allowStacking) {
+        int t = 0;
+        for (int b = 0; b < StaffLineGrid::columns; ++b)
+            if (expectedRow[b] != -1) ++t;
+        return t;
     }
+    // Stacking: one expected "slot" per distinct beat that has expected notes
+    bool hasBeat[StaffLineGrid::columns] = {};
+    for (const NoteInfo& note : m_expectedNotes)
+        if (note.beat >= 0 && note.beat < StaffLineGrid::columns)
+            hasBeat[note.beat] = true;
+    int t = 0;
+    for (int b = 0; b < StaffLineGrid::columns; ++b)
+        if (hasBeat[b]) ++t;
     return t;
 }
 
@@ -334,12 +402,13 @@ void GridController::loadQuestion(int questionNum) {
 
     // Clear user-placed notes and per-beat state
     userGrid.ClearGrid();
-    userAccidental.fill(0);
+    for (auto& rowArr : userAccidental) rowArr.fill(0);
     userLength.fill(0);
 
     // Reset expected answers to empty
     expectedRow.fill(-1);
     expectedAccidental.fill(0);
+    m_expectedNotes.clear();
 
     Question q = questionHandler.GetQuestion(questionNum);
     //debug question logic
@@ -361,10 +430,18 @@ void GridController::loadQuestion(int questionNum) {
     emit questionChanged();
 
 
-    // copy notes from question vector into arrays
-    for (const NoteInfo& note : q.notes) { if (note.beat >= 0 && note.beat < StaffLineGrid::columns && note.row >= 0 && note.row < StaffLineGrid::rows) {        
-            expectedRow[note.beat] = note.row;
-            expectedAccidental[note.beat] = note.accent;
+    // Copy expected notes into both storage structures.
+    // m_expectedNotes holds the full list (supports multiple per beat for chords).
+    // expectedRow/Accidental flat arrays are populated for non-stacking questions
+    // and used by the non-stacking grading path.
+    for (const NoteInfo& note : q.notes) {
+        if (note.beat >= 0 && note.beat < StaffLineGrid::columns
+            && note.row >= 0 && note.row < StaffLineGrid::rows) {
+            m_expectedNotes.push_back(note);
+            if (!m_allowStacking) {
+                expectedRow[note.beat] = note.row;
+                expectedAccidental[note.beat] = note.accent;
+            }
         }
     }
     // notify QML/UI that everything changed

--- a/core/GridController.cpp
+++ b/core/GridController.cpp
@@ -307,10 +307,39 @@ void GridController::runMillion() {
 }
 
 
+int GridController::currentQuestionNum() const {
+    return m_currentQuestionNum;
+}
+
+int GridController::totalQuestionsAvailable() {
+    return (int)questionHandler.GetQuestions().size();
+}
+
+void GridController::nextQuestion() {
+    int total = (int)questionHandler.GetQuestions().size();
+    if (m_currentQuestionNum < total)
+        loadQuestion(m_currentQuestionNum + 1);
+}
+
+void GridController::previousQuestion() {
+    if (m_currentQuestionNum > 1)
+        loadQuestion(m_currentQuestionNum - 1);
+}
+
 void GridController::loadQuestion(int questionNum) {
-    // reset expected answers to empty
+    int total = (int)questionHandler.GetQuestions().size();
+    if (questionNum < 1 || questionNum > total) return;
+
+    m_currentQuestionNum = questionNum;
+
+    // Clear user-placed notes and per-beat state
+    userGrid.ClearGrid();
+    userAccidental.fill(0);
+    userLength.fill(0);
+
+    // Reset expected answers to empty
     expectedRow.fill(-1);
-    expectedAccidental.fill(0);    
+    expectedAccidental.fill(0);
 
     Question q = questionHandler.GetQuestion(questionNum);
     //debug question logic

--- a/core/GridController.h
+++ b/core/GridController.h
@@ -21,10 +21,12 @@ public:
     Q_INVOKABLE void clearBeat(int beat);            // removes any note in that beat
     Q_INVOKABLE int  noteRowForBeat(int beat) const; // -1 if none
     Q_INVOKABLE int accidentalForBeat(int beat) const;
+    Q_INVOKABLE int accidentalForBeatRow(int beat, int row) const;
     Q_INVOKABLE int noteLengthForBeat(int beat) const;
     // grading
     Q_INVOKABLE void setExpectedRow(int beat, int row, int acc, int length = 1); // row -1 means "should be empty"
     Q_INVOKABLE bool isBeatCorrect(int beat) const;
+    Q_INVOKABLE bool isNoteIncorrect(int beat, int row) const;
     Q_INVOKABLE int  score() const;
     Q_INVOKABLE int  totalExpected() const;
     Q_INVOKABLE QVariantList incorrectBeats() const;
@@ -52,11 +54,14 @@ private:
     // expected answer: for each beat store the one correct row, or -1 for empty
     std::array<int, StaffLineGrid::columns> expectedRow{};
 
-    //-1 = fat, 0 = norm, +1 = sharp
+    //-1 = flat, 0 = natural, +1 = sharp — indexed [beat][row] to support stacked notes
     std::array<int, StaffLineGrid::columns> expectedAccidental{};
-    std::array<int, StaffLineGrid::columns> userAccidental{};
+    std::array<std::array<int, StaffLineGrid::rows>, StaffLineGrid::columns> userAccidental{};
     std::array<int, StaffLineGrid::columns> userLength{};
     std::array<int, StaffLineGrid::columns> expectedLength{};
+
+    // Full list of expected notes; supports multiple entries per beat for chord questions
+    std::vector<NoteInfo> m_expectedNotes;
 
     void clearBeatInternal(int beat);
 

--- a/core/GridController.h
+++ b/core/GridController.h
@@ -11,6 +11,7 @@
 class GridController : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString currentQuestionText READ currentQuestionText NOTIFY questionChanged)
+    Q_PROPERTY(int currentQuestionNum READ currentQuestionNum NOTIFY questionChanged)
 public:
     explicit GridController(QObject *parent = nullptr);
 
@@ -28,6 +29,10 @@ public:
     Q_INVOKABLE int  totalExpected() const;
     Q_INVOKABLE QVariantList incorrectBeats() const;
     Q_INVOKABLE void loadQuestion(int questionNum);
+    Q_INVOKABLE void nextQuestion();
+    Q_INVOKABLE void previousQuestion();
+    Q_INVOKABLE int  currentQuestionNum() const;
+    Q_INVOKABLE int  totalQuestionsAvailable();
     Q_INVOKABLE void runMillion();
 
     QString currentQuestionText() const;
@@ -56,6 +61,7 @@ private:
     void clearBeatInternal(int beat);
 
     QString m_currentQuestionText;
+    int m_currentQuestionNum = 0;
     std::vector<int> m_allowedLengths;
     std::vector<int> m_allowedStartColumns;
     bool m_allowStacking = false;

--- a/core/questionHandler.cpp
+++ b/core/questionHandler.cpp
@@ -32,35 +32,68 @@ static bool ParseBool(const string& field) {
     return field == "true" || field == "True" || field == "1";
 }
 
-// If the CSV field is: (0-4-0 2-5-0 4-6-0) it first removes the outer parentheses, leaving: 0-4-0 2-5-0 4-6-0
-//Then it reads each token: 0-4-0 2-5-0 4-6-0 and splits each one at the dashes.
+// Converts a pitch name like "F4", "Bb4", or "F#5" into a diatonic row index and
+// accidental value. Row 0 = C4; each octave adds 7 rows (white keys only).
+// Returns false if the string is not a recognised pitch name.
+static bool parsePitch(const string& pitch, int& outRow, int& outAccent) {
+    if (pitch.empty()) return false;
+
+    // Map note letter to diatonic offset: C=0 D=1 E=2 F=3 G=4 A=5 B=6
+    static const string noteLetters = "CDEFGAB";
+    size_t i = 0;
+    char letter = (char)toupper((unsigned char)pitch[i++]);
+    size_t noteIndex = noteLetters.find(letter);
+    if (noteIndex == string::npos) return false;
+
+    // Optional accidental modifier
+    int accent = 0;
+    if (i < pitch.size() && pitch[i] == 'b') { accent = -1; ++i; }
+    else if (i < pitch.size() && pitch[i] == '#') { accent =  1; ++i; }
+
+    // Octave digit
+    if (i >= pitch.size() || !isdigit((unsigned char)pitch[i])) return false;
+    int octave = pitch[i] - '0';
+
+    outRow    = (octave - 4) * 7 + (int)noteIndex;
+    outAccent = accent;
+    return true;
+}
+
+// Parses the answer field.  Each space-separated token is either:
+//   Pitch-name format  "beat-PitchName"  e.g. 0-F4, 6-Bb4, 14-F#5
+//   Legacy row format  "beat-row-accent"  e.g. 0-3-0, 6-6--1
+// Both formats may appear in the same field for backwards compatibility.
 static vector<NoteInfo> ParseNotes(const string& field) {
     vector<NoteInfo> notes;
 
     string cleaned = field;
-
-    if (!cleaned.empty() && cleaned.front() == '(') {
-        cleaned.erase(0, 1);
-    }
-    if (!cleaned.empty() && cleaned.back() == ')') {
-        cleaned.pop_back();
-    }
+    if (!cleaned.empty() && cleaned.front() == '(') cleaned.erase(0, 1);
+    if (!cleaned.empty() && cleaned.back() == ')')  cleaned.pop_back();
 
     stringstream ss(cleaned);
     string token;
 
     while (ss >> token) {
         size_t firstDash = token.find('-');
-        size_t secondDash = token.find('-', firstDash + 1);
-
-        if (firstDash == string::npos || secondDash == string::npos) {
-            continue;
-        }
+        if (firstDash == string::npos) continue;
 
         NoteInfo note;
         note.beat = stoi(token.substr(0, firstDash));
-        note.row = stoi(token.substr(firstDash + 1, secondDash - firstDash - 1));
-        note.accent = stoi(token.substr(secondDash + 1));
+        string rest = token.substr(firstDash + 1);
+
+        if (!rest.empty() && isalpha((unsigned char)rest[0])) {
+            // Pitch-name format: rest is something like "F4" or "Bb4"
+            if (!parsePitch(rest, note.row, note.accent)) {
+                cerr << "WARNING: unrecognised pitch '" << rest << "' in CSV, skipping\n";
+                continue;
+            }
+        } else {
+            // Legacy format: rest is "row-accent" e.g. "3-0" or "6--1"
+            size_t sepDash = rest.find('-');
+            if (sepDash == string::npos) continue;
+            note.row    = stoi(rest.substr(0, sepDash));
+            note.accent = stoi(rest.substr(sepDash + 1));
+        }
 
         notes.push_back(note);
     }

--- a/core/questions.csv
+++ b/core/questions.csv
@@ -1,3 +1,4 @@
 Question,Answer,AllowedLengths,AllowedStartColumns,AllowStacking,RequireAllFilled
 Write a C major scale,"(0-C4 2-D4 4-E4 6-F4 8-G4 10-A4 12-B4 14-C5)","2","0 2 4 6 8 10 12 14",false,true
 Write a F major scale,"(0-F4 2-G4 4-A4 6-Bb4 8-C5 10-D5 12-E5 14-F5)","2","0 2 4 6 8 10 12 14",false,true
+Write a C major chord,"(0-C4 0-E4 0-G4)","4","0",true,false

--- a/core/questions.csv
+++ b/core/questions.csv
@@ -1,2 +1,3 @@
 Question,Answer,AllowedLengths,AllowedStartColumns,AllowStacking,RequireAllFilled
-Write an F major scale,"(0-3-0 2-4-0 4-5-0 6-6--1 8-7-0 10-8-0 12-9-0 14-10-0)","2","0 2 4 6 8 10 12 14",false,true
+Write a C major scale,"(0-C4 2-D4 4-E4 6-F4 8-G4 10-A4 12-B4 14-C5)","2","0 2 4 6 8 10 12 14",false,true
+Write a F major scale,"(0-F4 2-G4 4-A4 6-Bb4 8-C5 10-D5 12-E5 14-F5)","2","0 2 4 6 8 10 12 14",false,true

--- a/core/staffLineGrid.h
+++ b/core/staffLineGrid.h
@@ -11,7 +11,12 @@ Summary: Data based grid of the staff lines. Currently handles if a note is at
 
 //Used for easy resizing
 #define columnsNum 16
-#define rowsNum 14 //C4 to B5 range
+// Row-to-pitch mapping (diatonic white keys only; accidentals stored separately as -1/0/+1):
+//   C4=0  D4=1  E4=2  F4=3  G4=4  A4=5  B4=6
+//   C5=7  D5=8  E5=9  F5=10 G5=11 A5=12 B5=13
+//   C6=14 D6=15 E6=16 F6=17 G6=18 A6=19 B6=20
+//   C7=21 D7=22
+#define rowsNum 23 // C4 to D7 range (23 diatonic pitches)
 
 struct Note {
     int column = 0; // Column of the note in the measure

--- a/tests/test_questionhandler.cpp
+++ b/tests/test_questionhandler.cpp
@@ -45,3 +45,46 @@ TEST(QuestionHandlerTest, ReadsCsvAndCreatesQuestions) {
     // Clean up.
     filesystem::remove(filename);
 }
+
+TEST(QuestionHandlerTest, PitchNameParsing) {
+    // Verify that pitch-name tokens like "0-F4" and "6-Bb4" are parsed correctly
+    // and produce the expected diatonic row and accidental values.
+    const string filename = "questions.csv";
+    const string data =
+        "Question,Answer,AllowedLengths,AllowedStartColumns,AllowStacking,RequireAllFilled\n"
+        "F major scale,\"(0-F4 2-G4 6-Bb4 8-C5)\",2,\"0 2 6 8\",false,false\n";
+
+    {
+        ofstream out(filename);
+        ASSERT_TRUE(out.is_open()) << "Unable to create temporary CSV file: " << filename;
+        out << data;
+    }
+
+    QuestionHandler handler;
+    vector<Question> questions = handler.GetQuestions();
+
+    ASSERT_EQ(questions.size(), 1u);
+    ASSERT_EQ(questions[0].notes.size(), 4u);
+
+    // F4: diatonic offset 3, octave 4 → row = (4-4)*7 + 3 = 3, accent = 0
+    EXPECT_EQ(questions[0].notes[0].beat,   0);
+    EXPECT_EQ(questions[0].notes[0].row,    3);
+    EXPECT_EQ(questions[0].notes[0].accent, 0);
+
+    // G4: diatonic offset 4, octave 4 → row = 4, accent = 0
+    EXPECT_EQ(questions[0].notes[1].beat,   2);
+    EXPECT_EQ(questions[0].notes[1].row,    4);
+    EXPECT_EQ(questions[0].notes[1].accent, 0);
+
+    // Bb4: B = offset 6, flat → row = 6, accent = -1
+    EXPECT_EQ(questions[0].notes[2].beat,   6);
+    EXPECT_EQ(questions[0].notes[2].row,    6);
+    EXPECT_EQ(questions[0].notes[2].accent, -1);
+
+    // C5: diatonic offset 0, octave 5 → row = (5-4)*7 + 0 = 7, accent = 0
+    EXPECT_EQ(questions[0].notes[3].beat,   8);
+    EXPECT_EQ(questions[0].notes[3].row,    7);
+    EXPECT_EQ(questions[0].notes[3].accent, 0);
+
+    filesystem::remove(filename);
+}


### PR DESCRIPTION
# Feature: Chord Stacking + Per-Note Grading + Note Length Fix

## Overview

This PR enables chord-based questions by allowing multiple notes per beat and fixes grading to operate at the individual note level instead of per beat.

It also resolves a note length mismatch that prevented whole and half notes from being placed correctly.

---

## 1. Chord Stacking (Multi-Note per Beat)

### What changed

* Enabled multiple notes on the same beat when `allowStacking = true`
* Updated `GridController::setNote()`:

  * In stacking mode, only clears the targeted `(beat, row)`
  * Preserves other notes at the same beat

### Result

* Supports chord questions like:

  ```
  (0-C4 0-E4 0-G4)
  ```
* Multiple notes render correctly in the same column

---

## 2. Per-Note Grading (Major Fix)

### Problem

Grading was previously done per beat:

* If one note was wrong → entire beat marked incorrect
* All notes at that beat showed ❌, even correct ones

### Fix

* Added:

  ```cpp
  Q_INVOKABLE bool isNoteIncorrect(int beat, int row) const;
  ```
* Updated `NoteSlot.qml`:

  * Replaced beat-level checks with note-level checks

### Result

* Only incorrect notes show ❌
* Correct notes remain visually correct
* Extra notes are flagged individually
* Missing notes do not incorrectly mark other notes

---

## 3. Note Length System Fix

### Problem

Mismatch between UI and backend note length conventions caused:

* Whole notes not placing
* Half notes being rejected

### Fix

Standardized note lengths across the system:

```
1 = eighth
2 = quarter
3 = half
4 = whole
```

Updated:

* `GridController::setNote()` switch logic
* `questions.csv` allowed lengths for chord questions

---

## Files Modified

* `core/GridController.h`
* `core/GridController.cpp`
* `app/NoteSlot.qml`
* `core/questions.csv`

---

## Manual Testing

### Chord Questions

* Place C4, E4, G4 at same beat → all render
* Missing note → only missing note affects grading
* Extra note → only extra note shows ❌
* Fully correct chord → no ❌

### Note Lengths

* Whole notes (length 4) place correctly at beat 0
* Half notes (length 3) place correctly at beats 0 and 4
* Quarter and eighth notes unchanged

### Non-Stacking Questions

* Scale questions still allow only one note per beat
* Grading behavior unchanged

---

## Notes

* `StaffLineGrid` required no changes (already supports stacking)
* QML changes were minimal (1-line update for grading logic)
* This PR builds directly on the pitch parser + grid expansion work in the previous PR
