### PR TITLE
fix:WSL devs added Audio Setup guide in SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -22,6 +22,12 @@ docker build --no-cache -t grade-your-melody -f docker/Dockerfile .
 ---
 
 ## Run the App
+### 1. Allow Docker to access display
+
+```bash
+xhost +local:docker
+```
+
 
 ## Build and Run (Local — With Audio)
 
@@ -33,20 +39,117 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 ./build/GradeYourMelody
 ```
-## Run with Audio in Docker (PulseAudio)
+
+# 🔊 Audio Setup (WSL + Docker)
+This guide explains how to get **audio working in WSL (Windows Subsystem for Linux)** using **WSLg**.
+---
+## 🧠 Background
+
+In WSL (Windows 11), audio is handled by **WSLg**, which exposes a PulseAudio server at:
+
+/mnt/wslg/PulseServer
+
+---
+## ✅ Step 1 — Verify PulseAudio is running in WSL
+Run:
+```bash
+ls -l /mnt/wslg/PulseServer
+```
+Expected: You should see a socket file (not "No such file or directory").
+---
+## ✅ Step 2 — Check PulseAudio connection
+Run:
+```bash
+echo $PULSE_SERVER
+pactl info
+```
+Expected output should include:
+```
+Server String: unix:/mnt/wslg/PulseServer
+Server Name: pulseaudio
+```
+---
+## ⚠️ Step 3 — Fix PulseAudio cookie issue (if needed)
+If you see:
+```
+Failed to read cookie file ... Is a directory
+```
+That means your cookie path is broken.
+**Fix it:**
+
+```bash
+rm -rf ~/.config/pulse/cookie
+
+```
+*(Optional)* Recreate directory:
+```bash
+mkdir -p ~/.config/pulse
+```
+> ⚠️ In WSLg, you do **NOT** need to manually manage the cookie — it is handled automatically.
+---
+## 🐳 Step 4 — Test PulseAudio inside Docker
+Run:
+
+```bash
+
+docker run --rm \
+  -e PULSE_SERVER=unix:/mnt/wslg/PulseServer \
+  -v /mnt/wslg:/mnt/wslg \
+  grade-your-melody pactl info
+```
+
+Expected:
+- Same PulseAudio info output as WSL
+- No "connection refused"
+---
+## 🚀 Step 5 — Run the app with audio
+```bash
+docker run --rm \
+  -e DISPLAY=$DISPLAY \
+  -e WAYLAND_DISPLAY=$WAYLAND_DISPLAY \
+  -e XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir \
+  -e PULSE_SERVER=unix:/mnt/wslg/PulseServer \
+  -v /mnt/wslg:/mnt/wslg \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  grade-your-melody ./build/GradeYourMelody
+```
+---
+```
+If you don't mount `/mnt/wslg`, audio will not work.
+
+---
+## ✏️ Quick Test
+
+After launching the app:
+
+- Place a note → you should hear preview audio
+- Click Play → full sequence should play
+
+---
+
+## 🧾 Summary
+
+| Requirement | Value |
+|-------------|-------|
+| Pulse server | `/mnt/wslg/PulseServer` |
+| Mount needed | `/mnt/wslg:/mnt/wslg` |
+| Works in WSL | ✅ Yes |
+
+```
+
+## Run with Audio in Docker (PulseAudio) for UBUNTU 22.04
 
 > ⚠️ This setup allows audio playback from inside the Docker container using PulseAudio.
 > Requires a Linux host with PulseAudio or PipeWire (Pulse compatibility).
-
 ---
 
 ### 1. Allow Docker to access display
 
 ```bash
 xhost +local:docker
-
-### 2. Run app with Audio enabled
-
+```
+### 2. For Linux Ubuntu: Run app with Audio enabled
+```bash
 docker run --rm \
   --user $(id -u):$(id -g) \
   -e DISPLAY=$DISPLAY \
@@ -79,13 +182,6 @@ If successful, it will print PulseAudio server information.
 ```bash
 xhost +local:docker
 docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix grade-your-melody ./build/GradeYourMelody
-```
-
-### WSL (Windows)
-1. Install **VcXsrv** or **X410** on Windows and start it
-2. Then run:
-```bash
-docker run -e DISPLAY=host.docker.internal:0 grade-your-melody ./build/GradeYourMelody
 ```
 
 ### Mac


### PR DESCRIPTION
# 🔊 Audio Setup (WSL + Docker)

This guide explains how to get **audio working in WSL (Windows Subsystem for Linux)** using **WSLg**.

---

## 🧠 Background

In WSL (Windows 11), audio is handled by **WSLg**, which exposes a PulseAudio server at:

```
/mnt/wslg/PulseServer
```

This is different from a normal Linux system (`/run/user/.../pulse/native`).

---

## ✅ Step 1 — Verify PulseAudio is running in WSL

Run:

```bash
ls -l /mnt/wslg/PulseServer
```

Expected: You should see a socket file (not "No such file or directory").

---

## ✅ Step 2 — Check PulseAudio connection

Run:

```bash
echo $PULSE_SERVER
pactl info
```

Expected output should include:

```
Server String: unix:/mnt/wslg/PulseServer
Server Name: pulseaudio
```

---

## ⚠️ Step 3 — Fix PulseAudio cookie issue (if needed)

If you see:

```
Failed to read cookie file ... Is a directory
```

That means your cookie path is broken.

**Fix it:**

```bash
rm -rf ~/.config/pulse/cookie
```

*(Optional)* Recreate directory:

```bash
mkdir -p ~/.config/pulse
```

> ⚠️ In WSLg, you do **NOT** need to manually manage the cookie — it is handled automatically.

---

## 🐳 Step 4 — Test PulseAudio inside Docker

Run:

```bash
docker run --rm \
  -e PULSE_SERVER=unix:/mnt/wslg/PulseServer \
  -v /mnt/wslg:/mnt/wslg \
  grade-your-melody pactl info
```

Expected:
- Same PulseAudio info output as WSL
- No "connection refused"

---

## 🚀 Step 5 — Run the app with audio

```bash
docker run --rm \
  -e DISPLAY=$DISPLAY \
  -e WAYLAND_DISPLAY=$WAYLAND_DISPLAY \
  -e XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir \
  -e PULSE_SERVER=unix:/mnt/wslg/PulseServer \
  -v /mnt/wslg:/mnt/wslg \
  -v /tmp/.X11-unix:/tmp/.X11-unix \
  grade-your-melody ./build/GradeYourMelody
```

---

## ❌ Common Mistakes

### 1. Using Linux PulseAudio path (WRONG for WSL)

```bash
/run/user/1000/pulse/native
```

👉 This will fail in WSL.

### 2. Mounting Pulse cookie (NOT needed in WSL)

```bash
-v ~/.config/pulse/cookie:/home/user/.config/pulse/cookie
```

👉 Can cause errors like:

```
Is a directory
Connection refused
```

### 3. Missing `/mnt/wslg` mount

If you don't mount `/mnt/wslg`, audio will not work.

---

## ✏️ Quick Test

After launching the app:

- Place a note → you should hear preview audio
- Click Play → full sequence should play

---

## 🧾 Summary

| Requirement | Value |
|-------------|-------|
| Pulse server | `/mnt/wslg/PulseServer` |
| Mount needed | `/mnt/wslg:/mnt/wslg` |
| Cookie needed | ❌ No |
| Works in WSL | ✅ Yes |

---

## 💡 Tip

If audio still fails:

```bash
wsl --shutdown
```

Then reopen your terminal and try again.