### PR TITLE
test: add QuestionHandler coverage for answer choices, CSV fallback b…

### DIFF
--- a/tests/test_questionhandler.cpp
+++ b/tests/test_questionhandler.cpp
@@ -127,3 +127,79 @@ TEST(QuestionHandlerTest, ChordWithFlatsParsesDistinctly) {
 
     filesystem::remove(filename);
 }
+
+TEST(QuestionHandlerTest, EarTrainingChoiceTextRoundTrip) {
+    // Verify that ChoiceA, ChoiceB, and CorrectChoice from a 9-column CSV row
+    // make it into the parsed Question unchanged.
+    const string filename = "questions.csv";
+    const string data =
+        "Question,Answer,AllowedLengths,AllowedStartColumns,AllowStacking,RequireAllFilled,ChoiceA,ChoiceB,CorrectChoice\n"
+        "Write a C minor chord,\"(0-C4 0-Eb4 0-G4)\",4,0,true,false,Major chord,Minor chord,B\n";
+
+    {
+        ofstream out(filename);
+        ASSERT_TRUE(out.is_open()) << "Unable to create temporary CSV file: " << filename;
+        out << data;
+    }
+
+    QuestionHandler handler;
+    vector<Question> questions = handler.GetQuestions();
+
+    ASSERT_EQ(questions.size(), 1u);
+    EXPECT_EQ(questions[0].choiceA,       "Major chord");
+    EXPECT_EQ(questions[0].choiceB,       "Minor chord");
+    EXPECT_EQ(questions[0].correctChoice, "B");
+
+    filesystem::remove(filename);
+}
+
+TEST(QuestionHandlerTest, LegacySixColumnDefaultsChoices) {
+    // Backward compatibility: a 6-column CSV (no ChoiceA/ChoiceB/CorrectChoice)
+    // must still parse, and the missing fields must fall back to safe defaults.
+    const string filename = "questions.csv";
+    const string data =
+        "Question,Answer,AllowedLengths,AllowedStartColumns,AllowStacking,RequireAllFilled\n"
+        "Legacy question,\"(0-C4)\",2,0,false,false\n";
+
+    {
+        ofstream out(filename);
+        ASSERT_TRUE(out.is_open()) << "Unable to create temporary CSV file: " << filename;
+        out << data;
+    }
+
+    QuestionHandler handler;
+    vector<Question> questions = handler.GetQuestions();
+
+    ASSERT_EQ(questions.size(), 1u);
+    EXPECT_EQ(questions[0].choiceA,       "Legacy question"); // defaults to questionText
+    EXPECT_EQ(questions[0].choiceB,       "");
+    EXPECT_EQ(questions[0].correctChoice, "A");
+
+    filesystem::remove(filename);
+}
+
+TEST(QuestionHandlerTest, MalformedRowsAreSkipped) {
+    // A row with fewer than 6 fields must be skipped without crashing,
+    // and valid rows on either side of it must still parse normally.
+    const string filename = "questions.csv";
+    const string data =
+        "Question,Answer,AllowedLengths,AllowedStartColumns,AllowStacking,RequireAllFilled\n"
+        "First valid question,\"(0-C4)\",2,0,false,false\n"
+        "broken,row,only-three\n"
+        "Second valid question,\"(0-D4)\",2,0,false,false\n";
+
+    {
+        ofstream out(filename);
+        ASSERT_TRUE(out.is_open()) << "Unable to create temporary CSV file: " << filename;
+        out << data;
+    }
+
+    QuestionHandler handler;
+    vector<Question> questions = handler.GetQuestions();
+
+    ASSERT_EQ(questions.size(), 2u);
+    EXPECT_EQ(questions[0].questionText, "First valid question");
+    EXPECT_EQ(questions[1].questionText, "Second valid question");
+
+    filesystem::remove(filename);
+}


### PR DESCRIPTION
# Parser Test Coverage Expansion

## Overview

This PR expands automated parser-level test coverage for the `QuestionHandler` system.

The goal of this branch was to improve confidence around the newer Ear Training CSV format additions while preserving backward compatibility with the original question format.

The changes focus entirely on automated tests and do not modify production parsing logic.

---

## Changes Added

### New Automated Tests

Added the following tests to `tests/test_questionhandler.cpp`:

---

#### `QuestionHandlerTest.EarTrainingChoiceTextRoundTrip`

Verifies that the extended 9-column CSV format correctly parses:
- `ChoiceA`
- `ChoiceB`
- `CorrectChoice`

Example covered:

```csv
Write a C minor chord,"(0-C4 0-Eb4 0-G4)","4","0",true,false,Major chord,Minor chord,B
```

---

#### `QuestionHandlerTest.LegacySixColumnDefaultsChoices`

Verifies backward compatibility with the original 6-column CSV format.

Confirms fallback behavior:
- `choiceA` defaults to `questionText`
- `choiceB` defaults to an empty string
- `correctChoice` defaults to `"A"`

---

#### `QuestionHandlerTest.MalformedRowsAreSkipped`

Verifies malformed CSV rows:
- Do not crash parsing
- Are safely skipped
- Do not corrupt valid surrounding rows

---

## Why This Matters

These tests improve confidence around:
- Ear Training answer-choice parsing
- CSV schema evolution
- Backward compatibility
- Parser regression prevention
- Malformed input handling

This PR also strengthens the project's automated testing foundation without introducing additional UI or Qt testing complexity.

---

## Scope

### Files Modified
- `tests/test_questionhandler.cpp`

### Files Not Modified
- `GridController`
- `AudioEngine`
- QML files
- Production parser logic
- CMake configuration

---

## Validation

Build and test commands:

```bash
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
cmake --build build
ctest --test-dir build -R QuestionHandlerTest --output-on-failure
```

---

## Notes

This PR intentionally keeps the tests **explicit**, **readable**, and **minimally abstracted** to make them approachable for teammates unfamiliar with advanced testing patterns.